### PR TITLE
Add --depth flag to set maximum TOC depth

### DIFF
--- a/actions/generate.go
+++ b/actions/generate.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GenerateToc generates the TOC for a given file.
-func GenerateToc(lines []string) []string {
+func GenerateToc(lines []string, maxDepth int) []string {
 	// Regular Expressions
 	regTitle := regexp.MustCompile(`#+(.*)`)
 	regHeading := regexp.MustCompile(`(?m)^[^\s]*#\s`)
@@ -24,6 +24,13 @@ func GenerateToc(lines []string) []string {
 			heading := regTitle.FindStringSubmatch(line)
 
 			currentHeading := strings.Count(heading[0], "#")
+
+			// if a maximum depth is set, and the current heading's depth is
+			// over that maximum, just ignore it.
+			if maxDepth > 0 && maxDepth < currentHeading {
+				continue
+			}
+
 			lowerHeading := strings.ToLower(heading[1])
 			kebabHeading := strings.ReplaceAll(strings.TrimSpace(lowerHeading), " ", "-")
 			title := strings.TrimSpace(heading[1])
@@ -35,16 +42,16 @@ func GenerateToc(lines []string) []string {
 				continue
 			}
 
-			if prevHeading == currentHeading{
+			if prevHeading == currentHeading {
 				lastitem := store[len(store)-1]
 
 				spaces := countLeadingSpaces(lastitem)
 				store = append(store, fmt.Sprintf("%*s- [%s](#%s)", spaces, "", title, kebabHeading))
 			}
 
-			if prevHeading > currentHeading || prevHeading < currentHeading{
-					spaces := currentHeading * 2
-					store = append(store, fmt.Sprintf("%*s- [%s](#%s)", spaces, "", title, kebabHeading))
+			if prevHeading > currentHeading || prevHeading < currentHeading {
+				spaces := currentHeading * 2
+				store = append(store, fmt.Sprintf("%*s- [%s](#%s)", spaces, "", title, kebabHeading))
 			}
 
 		}

--- a/toc.go
+++ b/toc.go
@@ -3,12 +3,13 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/urfave/cli/v2"
-	"github.com/yankeexe/toc-md/actions"
-	"github.com/yankeexe/toc-md/utils"
 	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+	"github.com/yankeexe/toc-md/actions"
+	"github.com/yankeexe/toc-md/utils"
 )
 
 func main() {
@@ -26,6 +27,12 @@ func main() {
 					Usage:   "Inject TOC to file",
 					Aliases: []string{"i"},
 				},
+				&cli.IntFlag{
+					Name:    "depth",
+					Usage:   "Depth of TOC to generate; the default 0 means that the depth is unlimited",
+					Aliases: []string{"d"},
+					Value:   0,
+				},
 			},
 
 			Action: func(c *cli.Context) error {
@@ -37,7 +44,7 @@ func main() {
 				}
 
 				// Get argument value
-				inject := c.Args().Get(1)
+				inject := c.Bool("inject")
 				fileLocation := c.Args().Get(0)
 				extension := filepath.Ext(fileLocation)
 
@@ -55,10 +62,10 @@ func main() {
 					lines = append(lines, scanner.Text())
 				}
 
-				result := actions.GenerateToc(lines)
+				result := actions.GenerateToc(lines, c.Int("depth"))
 
 				// Inject to file or stdout.
-				if inject != "" {
+				if inject {
 					actions.InjectToc(lines, result, file)
 				} else {
 					for _, item := range result {


### PR DESCRIPTION
This PR adds a `--depth` flag to TOC generation to set a maximum TOC depth. The default is 0 which indicates that no maximum depth is enforced. A value greater than 0 indicates the maximum depth that will be added to the TOC, e.g. 1 will only include level 1 headings, 2 will only include level 1 and 2 headings, etc.

It also fixes how the `--inject` flag is read and interpreted as this is a tiny bug I came across when manually testing my change.